### PR TITLE
fix(study and sandbox): add loading screen if deleting a study or san…

### DIFF
--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -81,6 +81,7 @@ const Sandbox: React.FC<SandboxProps> = ({}) => {
                 setUserClickedDelete={setUserClickedDelete}
                 userClickedDelete={userClickedDelete}
                 setResources={setResources}
+                setLoading={SandboxResponse.setLoading}
             />
             {returnStepComponent()}
             {(step === 0 || step === 1) && (

--- a/src/components/sandbox/StepBar.tsx
+++ b/src/components/sandbox/StepBar.tsx
@@ -45,6 +45,7 @@ type StepBarProps = {
     userClickedDelete: any;
     setUserClickedDelete: any;
     setResources: any;
+    setLoading: any;
 };
 
 const getSteps = () => {
@@ -81,7 +82,8 @@ const StepBar: React.FC<StepBarProps> = ({
     setUpdateCache,
     setResources,
     userClickedDelete,
-    setUserClickedDelete
+    setUserClickedDelete,
+    setLoading
 }) => {
     const history = useHistory();
     const steps = getSteps();
@@ -137,8 +139,11 @@ const StepBar: React.FC<StepBarProps> = ({
     };
 
     const deleteThisSandbox = (): void => {
+        setUserClickedDelete(false);
+        setLoading(true);
         setUpdateCache({ ...updateCache, ['studies/' + studyId]: true });
         deleteSandbox(sandboxId).then((result: any) => {
+            setLoading(false);
             if (result.Message) {
                 notify.show('danger', '500', result.Message, result.RequestId);
             }

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -206,8 +206,11 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
     };
 
     const deleteThisStudy = (): void => {
+        setUserClickedDelete(false);
+        setLoading(true);
         setUpdateCache({ ...updateCache, '/studies': true });
         deleteStudy(study.id).then((result: any) => {
+            setLoading(false);
             if (result.Message) {
                 notify.show('danger', '500', result.Message, result.RequestId);
             } else {


### PR DESCRIPTION
…dbox takes a while. For instance if a study needs to delete datasets as well as the study when user deletes study

Closes #413