### PR TITLE
fix(study): delete button visibility check for studyClose instead of studyDelete

### DIFF
--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -278,7 +278,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
     };
 
     const studyDeleteEnabled =
-        study.sandboxes && study.sandboxes.length === 0 && study.permissions && study.permissions.deleteStudy;
+        study.sandboxes && study.sandboxes.length === 0 && study.permissions && study.permissions.closeStudy;
     const optionsTemplate = (
         <>
             <Tooltip title={studyDeleteEnabled ? '' : returnTooltipText()} placement="left">


### PR DESCRIPTION
Delete study button is disabled for sponsors, because front end checks the studyDelete permission.
But since studies are not being deleted, but closed, we change to evaluationg studyClose instead