### PR TITLE
fix(study): clear participant search box after typing

### DIFF
--- a/src/components/studyDetails/ParticipantComponent.tsx
+++ b/src/components/studyDetails/ParticipantComponent.tsx
@@ -168,9 +168,7 @@ const ParicipantComponent: React.FC<ParicipantComponentProps> = ({ study, setStu
     const handleInputChange = (value: string) => {
         setRole('');
         setRoleNotSelected(true);
-        if (value !== '') {
-            setText(value);
-        } else if (value === '' && text.length === 1) {
+        if (value === '' && text.length === 1) {
             setText('');
             setParticipantNotSelected(true);
         }


### PR DESCRIPTION
The text would remain there when it should dissapear after typing

Closes #1033