### PR TITLE
fix:(study): create button disabled with invalid wbs

### DIFF
--- a/src/components/common/helpers/studyHelpers.tsx
+++ b/src/components/common/helpers/studyHelpers.tsx
@@ -4,11 +4,12 @@ import { isIterable, validateResourceName } from './helpers';
 export const validateUserInputStudy = (
     study: StudyObj,
     validWBS: boolean | undefined,
-    wbsLoading: boolean
+    wbsLoading: boolean,
+    newStudy: boolean
 ): boolean => {
     let result = true;
 
-    if (wbsLoading) {
+    if (wbsLoading && !newStudy) {
         result = false;
     }
 

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -248,7 +248,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
         setHasChanged(false);
         setUserPressedCreate(true);
         validateWbs(studyOnChange.wbsCode);
-        if (!validateUserInputStudy(studyOnChange, wbsOnChangeIsValid, validateWbsInProgress)) {
+        if (!validateUserInputStudy(studyOnChange, wbsOnChangeIsValid, validateWbsInProgress, newStudy)) {
             return;
         }
         if (imageUrl) {
@@ -269,11 +269,12 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
     const returnTooltipTextSaveStudy = () => {
         if (
             wbsOnChangeIsValid === false &&
+            !newStudy &&
             ((study.sandboxes && study.sandboxes.length) || (study.datasets && study.datasets.length))
         ) {
             return 'Can not change WBS to invalid wbs with active resources';
         }
-        if (!validateUserInputStudy(studyOnChange, wbsOnChangeIsValid, validateWbsInProgress)) {
+        if (!validateUserInputStudy(studyOnChange, wbsOnChangeIsValid, validateWbsInProgress, newStudy)) {
             return 'Please fill out all required fields';
         }
         return '';
@@ -623,7 +624,8 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                                                 wbsOnChangeIsValid !== undefined
                                                                     ? wbsOnChangeIsValid
                                                                     : wbsIsValid,
-                                                                validateWbsInProgress
+                                                                validateWbsInProgress,
+                                                                newStudy
                                                             )
                                                         }
                                                     >


### PR DESCRIPTION
You should be allowed to create a wbs with an invalid wbs. It is only when you have active resources that you should be required to have a valid wbs

Closes #1036