### PR TITLE
fix: truncate and fix ui issues with long names

### DIFF
--- a/src/components/common/customComponents/DeleteResourceComponent.tsx
+++ b/src/components/common/customComponents/DeleteResourceComponent.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useRef } from 'react';
-import { Button, Typography, TextField, Scrim } from '@equinor/eds-core-react';
+import { Button, Typography, TextField, Scrim, Tooltip, Icon } from '@equinor/eds-core-react';
 import styled from 'styled-components';
 import useClickOutside from './useClickOutside';
+import { truncate } from '../helpers/helpers';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
 
 const Wrapper = styled.div`
     display: grid;
@@ -36,6 +38,7 @@ const DeleteResourceComponent: React.FC<DeleteResourceComponentProps> = ({
     const [text, setText] = useState<string>('');
     const wrapperRef = useRef(null);
     useClickOutside(wrapperRef, setUserClickedDelete);
+    const [copied, setCopied] = useState<boolean>(false);
 
     const checkSandboxNameToText = (): boolean => {
         if (text === ResourceName) {
@@ -52,7 +55,20 @@ const DeleteResourceComponent: React.FC<DeleteResourceComponentProps> = ({
         <Scrim>
             <Wrapper ref={wrapperRef}>
                 <Typography variant="h4">
-                    Sure you want to delete the {type} with name "{ResourceName}"?
+                    Sure you want to delete the {type} with name "{truncate(ResourceName, 24)}"?
+                    <Tooltip title="Copy to clipboard" placement="top">
+                        <div style={{ display: 'inline-block' }}>
+                            <CopyToClipboard text={ResourceName} onCopy={() => setCopied(true)}>
+                                <Icon
+                                    name={copied ? 'check' : 'copy'}
+                                    style={{ marginLeft: '8px', marginBottom: '-4px' }}
+                                    size={24}
+                                    color="#007079"
+                                    className="icon"
+                                />
+                            </CopyToClipboard>
+                        </div>
+                    </Tooltip>
                 </Typography>
                 <TextField
                     id="textfield11"

--- a/src/components/home/StudyComponent.tsx
+++ b/src/components/home/StudyComponent.tsx
@@ -5,6 +5,7 @@ import { visibility, visibility_off } from '@equinor/eds-icons';
 import CustomLogoComponent from '../common/customComponents/CustomLogoComponent';
 import { StudyObj } from '../common/interfaces';
 import { useHistory } from 'react-router-dom';
+import { truncate } from 'components/common/helpers/helpers';
 
 const icons = {
     visibility,
@@ -66,6 +67,8 @@ type StudyComponentProps = {
     study: StudyObj;
 };
 
+const truncateLength = 48;
+
 const StudyComponent: React.FC<StudyComponentProps> = ({ study }) => {
     const { name, description, restricted, id, vendor, logoUrl } = study;
     const url = '/studies/' + id;
@@ -76,9 +79,8 @@ const StudyComponent: React.FC<StudyComponentProps> = ({ study }) => {
             <LogoTitleWrapper>
                 <CustomLogoComponent logoUrl={logoUrl} center />
                 <div>
-                    <Typography variant="h6">{name}</Typography>
-                    <SmallText>{vendor}</SmallText>
-
+                    <Typography variant="h6">{truncate(name, truncateLength)}</Typography>
+                    <SmallText>{truncate(vendor, truncateLength)}</SmallText>
                     <HiddenWrapper>
                         <SmallText style={{ marginTop: '4px' }}>{restricted ? 'Hidden' : 'Not hidden'}</SmallText>
                         <div>

--- a/src/components/sandbox/components/Dataset.tsx
+++ b/src/components/sandbox/components/Dataset.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Table, Checkbox, Tooltip } from '@equinor/eds-core-react';
-import { AvailableDatasetObj, SandboxObj, SandboxPermissions } from '../../common/interfaces';
+import { AvailableDatasetObj, DatasetObj, SandboxObj, SandboxPermissions } from '../../common/interfaces';
 import { deleteDatasetForSandbox, putDatasetForSandbox } from '../../../services/Api';
 import useFetchUrl from '../../common/hooks/useFetchUrl';
 import {
@@ -13,6 +13,7 @@ import {
 } from '../../../services/ApiCallStrings';
 import '../../../styles/Table.scss';
 import { getStudyId } from 'utils/CommonUtil';
+import { truncate } from 'components/common/helpers/helpers';
 
 const SatusWrapper = styled.div`
     display: flex;
@@ -93,6 +94,16 @@ const Dataset: React.FC<datasetProps> = ({
         }
     };
 
+    const returnTooltipTextDataset = (_dataset: AvailableDatasetObj) => {
+        if (permissions && !permissions.update) {
+            return 'You do not have access to update data sets in sandbox';
+        }
+        if (_dataset.name.length > 23) {
+            return _dataset.name;
+        }
+        return '';
+    };
+
     return (
         <div style={{ height: '331px', overflow: 'auto' }}>
             <Table style={{ width: '100%', marginBottom: '24px' }}>
@@ -109,18 +120,15 @@ const Dataset: React.FC<datasetProps> = ({
                                 <Row key={dataset.datasetId} id="tableRowNoPointerNoColor">
                                     <Cell>
                                         <SatusWrapper style={{ paddingBottom: '0px' }}>
-                                            <span data-cy="add_dataset_to_sandbox">
-                                                <Tooltip
-                                                    title={
-                                                        permissions && permissions.update
-                                                            ? ''
-                                                            : 'You do not have access to update data sets in sandbox'
-                                                    }
-                                                    placement="right"
-                                                >
+                                            <Tooltip
+                                                title={returnTooltipTextDataset(dataset)}
+                                                placement="right"
+                                                enterDelay={500}
+                                            >
+                                                <span data-cy="add_dataset_to_sandbox">
                                                     <Checkbox
                                                         defaultChecked={dataset.addedToSandbox}
-                                                        label={dataset.name}
+                                                        label={truncate(dataset.name, 23)}
                                                         disabled={
                                                             (permissions && !permissions.update) ||
                                                             addDatasetInProgress[dataset.datasetId] === true
@@ -129,8 +137,8 @@ const Dataset: React.FC<datasetProps> = ({
                                                             handleCheck(e, dataset);
                                                         }}
                                                     />
-                                                </Tooltip>
-                                            </span>
+                                                </span>
+                                            </Tooltip>
                                         </SatusWrapper>
                                     </Cell>
                                     <Cell>

--- a/src/components/studyDetails/CreateSandboxComponent.tsx
+++ b/src/components/studyDetails/CreateSandboxComponent.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Button, TextField, Tooltip, Icon } from '@equinor/eds-core-react';
 import { EquinorIcon, Label } from '../common/StyledComponents';
 import { SandboxCreateObj, DropdownObj, StudyObj } from '../common/interfaces';
-import { returnTextfieldTypeBasedOninput } from '../common/helpers/helpers';
+import { returnAllowedLengthOfString, returnTextfieldTypeBasedOninput } from '../common/helpers/helpers';
 import { validateUserInputSandbox } from '../common/helpers/sandboxHelpers';
 import CoreDevDropdown from '../common/customComponents/Dropdown';
 import styled from 'styled-components';
@@ -38,6 +38,10 @@ type CreateSandboxComponentProps = {
     wbsIsValid: boolean | undefined;
 };
 
+const limits = {
+    name: 127
+};
+
 const CreateSandboxComponent: React.FC<CreateSandboxComponentProps> = ({
     setToggle,
     setStudy,
@@ -66,9 +70,10 @@ const CreateSandboxComponent: React.FC<CreateSandboxComponentProps> = ({
     });
     const handleChange = (columnName: string, value: string) => {
         setHasChanged(true);
+        const setterValue = returnAllowedLengthOfString(limits, value, columnName);
         setSandbox({
             ...sandbox,
-            [columnName]: value
+            [columnName]: setterValue
         });
     };
     const handleDropdownChange = (value, name: string): void => {

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -13,7 +13,8 @@ import {
     checkIfRequiredFieldsAreNull,
     returnAllowedLengthOfString,
     returnLimitMeta,
-    returnTextfieldTypeBasedOninput
+    returnTextfieldTypeBasedOninput,
+    truncate
 } from '../common/helpers/helpers';
 import { validateUserInputStudy } from '../common/helpers/studyHelpers';
 import { useHistory } from 'react-router-dom';
@@ -128,6 +129,8 @@ const limits = {
     vendor: 128,
     wbsCode: 64
 };
+
+const truncateLength = 48;
 
 type StudyComponentFullProps = {
     study: StudyObj;
@@ -409,11 +412,23 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                     <TitleWrapper editMode={editMode}>
                         {!editMode ? (
                             <>
-                                <TitleText>{name}</TitleText>
-                                <SmallIconWrapper>
-                                    <Icon color="#007079" name="business" size={24} />
-                                    <SmallText>{vendor}</SmallText>
-                                </SmallIconWrapper>
+                                <Tooltip
+                                    title={name && name.length > truncateLength ? name : ''}
+                                    placement="top"
+                                    enterDelay={200}
+                                >
+                                    <TitleText>{truncate(name, truncateLength)}</TitleText>
+                                </Tooltip>
+                                <Tooltip
+                                    title={vendor && vendor.length > truncateLength ? vendor : ''}
+                                    placement="top"
+                                    enterDelay={500}
+                                >
+                                    <SmallIconWrapper>
+                                        <Icon color="#007079" name="business" size={24} />
+                                        <SmallText>{truncate(vendor, truncateLength)}</SmallText>
+                                    </SmallIconWrapper>
+                                </Tooltip>
                                 <SmallIconWrapper>
                                     <Icon color="#007079" name="dollar" size={24} />
                                     <SmallText>{wbsCode || '-'}</SmallText>
@@ -435,7 +450,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                     autoFocus
                                     inputIcon={
                                         <Tooltip
-                                            title="The value must be between 3 and 20 characters long (A-Z)"
+                                            title="The value must be between 3 and 128 characters long (A-Z)"
                                             placement="right"
                                         >
                                             <Icon name="info_circle" />

--- a/src/components/studyDetails/Tables/DatasetsTable.tsx
+++ b/src/components/studyDetails/Tables/DatasetsTable.tsx
@@ -4,6 +4,7 @@ import { Table } from '@equinor/eds-core-react';
 import { Link, useHistory } from 'react-router-dom';
 import { EquinorIcon } from '../../common/StyledComponents';
 import '../../../styles/Table.scss';
+import { truncate } from 'components/common/helpers/helpers';
 
 const { Body, Row, Cell, Head } = Table;
 
@@ -65,8 +66,8 @@ const DatasetsTable = (props: any) => {
                                                         onMouseLeave={() => setMouseHoverSandbox(false)}
                                                     >
                                                         {index === row.sandboxes.length - 1
-                                                            ? sandbox && sandbox.name
-                                                            : sandbox.name && sandbox.name + ', '}
+                                                            ? sandbox && truncate(sandbox.name, 48)
+                                                            : sandbox.name && truncate(sandbox.name, 48) + ', '}
                                                     </Link>
                                                 );
                                             })}


### PR DESCRIPTION
Long study, sandbox and data set names would make the ui look weird. Truncate them and add tooltips. Deleting a resource with a very long name was also buggy. Name went outside window

Closes #1042
Closes #1013