### PR TITLE
fix(study): disable create sandbox and dataset when saving study

### DIFF
--- a/src/components/studyDetails/DataSetComponent.tsx
+++ b/src/components/studyDetails/DataSetComponent.tsx
@@ -55,6 +55,7 @@ type DatasetComponentProps = {
     setUpdateCache: any;
     updateCache: any;
     wbsIsValid: boolean | undefined;
+    studySaveInProgress: boolean;
 };
 
 const DataSetComponent: React.FC<DatasetComponentProps> = ({
@@ -62,7 +63,8 @@ const DataSetComponent: React.FC<DatasetComponentProps> = ({
     setStudy,
     setUpdateCache,
     updateCache,
-    wbsIsValid
+    wbsIsValid,
+    studySaveInProgress
 }) => {
     const history = useHistory();
     //const [datasetsList, setDatasetsList] = useState<any>([]);
@@ -87,8 +89,14 @@ const DataSetComponent: React.FC<DatasetComponentProps> = ({
     };
 
     useEffect(() => {
-        setCanCreateDataset(study.permissions && study.permissions.addRemoveDataset && study.wbsCode && wbsIsValid);
-    }, [wbsIsValid]);
+        setCanCreateDataset(
+            study.permissions &&
+                study.permissions.addRemoveDataset &&
+                study.wbsCode &&
+                wbsIsValid &&
+                !studySaveInProgress
+        );
+    }, [wbsIsValid, studySaveInProgress]);
 
     const redirectToStudySpecificDataset = () => {
         const studyId = getStudyId();

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -148,6 +148,7 @@ type StudyComponentFullProps = {
     setDeleteStudyInProgress: any;
     setWbsIsValid: any;
     wbsIsValid: boolean | undefined;
+    setStudySaveInProgress: any;
 };
 
 const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
@@ -164,7 +165,8 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
     updateCache,
     setDeleteStudyInProgress,
     setWbsIsValid,
-    wbsIsValid
+    wbsIsValid,
+    setStudySaveInProgress
 }) => {
     const history = useHistory();
     const { id, logoUrl, name, description, wbsCode, vendor, restricted } = study;
@@ -174,7 +176,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
     const [userClickedDelete, setUserClickedDelete] = useState<boolean>(false);
     const [showImagePicker, setShowImagePicker] = useState<boolean>(false);
     const [userPressedCreate, setUserPressedCreate] = useState<boolean>(false);
-    const [wbsOnChangeIsValid, setWbsOnChangeIsValid] = useState<boolean | undefined>(undefined);
+    const [wbsOnChangeIsValid, setWbsOnChangeIsValid] = useState<boolean | undefined>(wbsIsValid);
     const [validateWbsInProgress, setValidateWbsInProgress] = useState<boolean>(false);
 
     const [state, setState] = React.useState<{
@@ -255,7 +257,10 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
         setUpdateCache({ ...updateCache, [getStudiesUrl()]: true });
         setShowImagePicker(false);
         setHasChanged(false);
-        setWbsIsValid(wbsOnChangeIsValid);
+        if (wbsOnChangeIsValid !== undefined) {
+            setWbsIsValid(wbsOnChangeIsValid);
+        }
+
         setUserPressedCreate(true);
         if (!validateUserInputStudy(studyOnChange, wbsOnChangeIsValid, validateWbsInProgress, newStudy)) {
             return;
@@ -323,10 +328,12 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
 
     const sendStudyToApi = (study: StudyObj) => {
         setLoading(true);
+        setStudySaveInProgress(true);
         if (newStudy) {
             createStudy(study, imageUrl).then((result: any) => {
                 if (result && !result.message) {
                     setLoading(false);
+                    setStudySaveInProgress(false);
                     const newStudy = result;
                     cache[getStudyByIdUrl(study.id)] = result;
                     setStudy(newStudy);
@@ -343,7 +350,9 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                 setStudy(studyOnChange);
             }
             setLoading(false);
+
             updateStudy(study, imageUrl).then((result: any) => {
+                setStudySaveInProgress(false);
                 if (result && !result.message) {
                     cache[getStudyByIdUrl(study.id)] = result;
                     setHasChanged(false);

--- a/src/components/studyDetails/StudyDetails.tsx
+++ b/src/components/studyDetails/StudyDetails.tsx
@@ -76,7 +76,8 @@ const StudyDetails = () => {
 
     const [hasChanged, setHasChanged] = useState<boolean>(false);
     const [deleteStudyInProgress, setDeleteStudyInProgress] = useState<boolean>(false);
-    const [loading, setLoading] = useState<Boolean>(false);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [studySaveInProgress, setStudySaveInProgress] = useState<boolean>(false);
     const studyResponse = useFetchUrl(getStudyByIdUrl(id), setStudy, id ? true : false, controller);
     const [wbsIsValid, setWbsIsValid] = useState<boolean | undefined>(undefined);
     const [resultsAndLearnings, setResultsAndLearnings] = useState<resultsAndLearningsObj>({ resultsAndLearnings: '' });
@@ -94,7 +95,8 @@ const StudyDetails = () => {
 
     useEffect(() => {
         setWbsIsValid(study.wbsCodeValid);
-    }, [study]);
+        console.log(study.wbsCodeValid);
+    }, [study.wbsCodeValid]);
 
     const changeComponent = () => {
         Cookies.remove(id);
@@ -108,6 +110,7 @@ const StudyDetails = () => {
                         setUpdateCache={setUpdateCache}
                         updateCache={updateCache}
                         wbsIsValid={wbsIsValid}
+                        studySaveInProgress={studySaveInProgress}
                     />
                 );
             case 2:
@@ -118,7 +121,7 @@ const StudyDetails = () => {
                         setHasChanged={setHasChanged}
                         setUpdateCache={setUpdateCache}
                         updateCache={updateCache}
-                        disabled={study.permissions && !study.permissions.addRemoveSandbox}
+                        disabled={!(study.permissions && study.permissions.addRemoveSandbox && !studySaveInProgress)}
                         study={study}
                         setLoading={setLoading}
                         wbsIsValid={wbsIsValid}
@@ -170,6 +173,7 @@ const StudyDetails = () => {
                         setDeleteStudyInProgress={setDeleteStudyInProgress}
                         setWbsIsValid={setWbsIsValid}
                         wbsIsValid={wbsIsValid}
+                        setStudySaveInProgress={setStudySaveInProgress}
                     />
                 ) : (
                     <LoadingWrapper />


### PR DESCRIPTION
This prevents some ugly side effects that can happen if you try to create a sandbox when changing from an invalid to valid wbs

Closes #1097