### PR TITLE
fix: add helpertext when typing long inputs

### DIFF
--- a/src/components/common/helpers/helpers.tsx
+++ b/src/components/common/helpers/helpers.tsx
@@ -21,9 +21,12 @@ export const checkIfRequiredFieldsAreNull = (value: any, userPressedCreate?: boo
     return 'default';
 };
 
-export const returnTextfieldTypeBasedOninput = (value: any, dashAllowed = true) => {
-    if (!validateResourceName(value, dashAllowed) && value !== '') {
+export const returnTextfieldTypeBasedOninput = (value: any, dashAllowed = true, limit = 50) => {
+    if (!validateResourceName(value, dashAllowed) && value !== '' && value !== undefined) {
         return 'error';
+    }
+    if (value && value.length > limit) {
+        return 'warning';
     }
     return 'default';
 };
@@ -131,4 +134,11 @@ export const returnAllowedLengthOfString = (limits: any, value: string, columnNa
         return value.substr(0, limits[columnName]);
     }
     return value;
+};
+
+export const returnHelperText = (inputLength: number, limit: number, type: string) => {
+    if (inputLength === undefined || inputLength <= limit) {
+        return '';
+    }
+    return `ProTip! Good ${type} names contain fewer than ${limit} characters.`;
 };

--- a/src/components/dataset/CreateEditDataset.tsx
+++ b/src/components/dataset/CreateEditDataset.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react';
 import CoreDevDropdown from '../common/customComponents/Dropdown';
 import styled from 'styled-components';
-import { Button, Typography, TextField, DotProgress, Tooltip } from '@equinor/eds-core-react';
+import { Button, Typography, TextField, DotProgress, Tooltip, Icon } from '@equinor/eds-core-react';
 import { DatasetObj, DropdownObj } from '../common/interfaces';
 import {
     addStudySpecificDataset,
@@ -9,7 +9,12 @@ import {
     createStandardDataset,
     updateStandardDataset
 } from '../../services/Api';
-import { checkColumDoesNotExceedInputLength, checkIfRequiredFieldsAreNull } from '../common/helpers/helpers';
+import {
+    checkColumDoesNotExceedInputLength,
+    checkIfRequiredFieldsAreNull,
+    returnHelperText,
+    returnTextfieldTypeBasedOninput
+} from '../common/helpers/helpers';
 import { checkForInputErrors } from '../common/helpers/datasetHelpers';
 import Promt from '../common/Promt';
 import { UpdateCache } from '../../App';
@@ -294,7 +299,9 @@ const CreateEditDataset: React.FC<CreateEditDatasetProps> = ({
                         placeholder="Please add data set name..."
                         label="Dataset name"
                         meta="(required)"
-                        variant={checkIfRequiredFieldsAreNull(dataset?.name, userPressedCreate)}
+                        variant={returnTextfieldTypeBasedOninput(dataset?.name)}
+                        helperText={returnHelperText(dataset?.name.length, 50, 'dataset')}
+                        helperIcon={<Icon name="warning_filled" title="Warning" />}
                         style={{ width, backgroundColor: '#FFFFFF' }}
                         onChange={(e: any) => handleChange('name', e.target.value)}
                         value={dataset?.name}

--- a/src/components/studyDetails/CreateSandboxComponent.tsx
+++ b/src/components/studyDetails/CreateSandboxComponent.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button, TextField, Tooltip, Icon } from '@equinor/eds-core-react';
-import { EquinorIcon, Label } from '../common/StyledComponents';
 import { SandboxCreateObj, DropdownObj, StudyObj } from '../common/interfaces';
-import { returnAllowedLengthOfString, returnTextfieldTypeBasedOninput } from '../common/helpers/helpers';
+import {
+    returnAllowedLengthOfString,
+    returnHelperText,
+    returnTextfieldTypeBasedOninput
+} from '../common/helpers/helpers';
 import { validateUserInputSandbox } from '../common/helpers/sandboxHelpers';
 import CoreDevDropdown from '../common/customComponents/Dropdown';
 import styled from 'styled-components';
@@ -16,7 +19,7 @@ import { getStudyId } from 'utils/CommonUtil';
 const Wrapper = styled.div`
     position: absolute;
     display: grid;
-    grid-template-rows: 1fr 24px 1fr auto;
+    grid-template-rows: 1fr 64px 48px;
     grid-gap: 8px;
     background-color: #ffffff;
     width: 300px;
@@ -112,8 +115,14 @@ const CreateSandboxComponent: React.FC<CreateSandboxComponentProps> = ({
                 placeholder="Please add Sandbox name..."
                 label="Sandbox name"
                 meta="(required)"
-                variant={returnTextfieldTypeBasedOninput(sandbox.name)}
+                variant={returnTextfieldTypeBasedOninput(sandbox.name, false)}
                 onChange={(e: any) => handleChange('name', e.target.value)}
+                helperText={
+                    sandbox.name.length > 50
+                        ? returnHelperText(sandbox.name.length, 50, 'sandbox')
+                        : 'Name cannot be changed later'
+                }
+                helperIcon={<Icon name="warning_outlined" title="Warning" />}
                 value={sandbox.name}
                 data-cy="sandbox_name"
                 autoComplete="off"
@@ -126,10 +135,10 @@ const CreateSandboxComponent: React.FC<CreateSandboxComponentProps> = ({
                     </div>
                 }
             />
-            <Label>
+            {/*<Label>
                 <span style={{ marginRight: '8px' }}>{EquinorIcon('warning_outlined', '#6F6F6F', 24)}</span>Name cannot
                 be changed later
-            </Label>
+            </Label>*/}
             <CoreDevDropdown
                 label="Location"
                 options={regions}
@@ -156,7 +165,7 @@ const CreateSandboxComponent: React.FC<CreateSandboxComponentProps> = ({
                     placement="left"
                 >
                     <Button
-                        style={{ width: '76px', margin: '8px 0 8px auto' }}
+                        style={{ width: '76px' }}
                         onClick={() => CreateSandbox()}
                         data-cy="create_actual_sandbox"
                         disabled={!(validateUserInputSandbox(sandbox, study.wbsCode) && wbsIsValid)}

--- a/src/components/studyDetails/Overview.tsx
+++ b/src/components/studyDetails/Overview.tsx
@@ -5,7 +5,7 @@ import SandboxTable from './Tables/SandboxTable';
 import { Button, TextField, Tooltip, Typography } from '@equinor/eds-core-react';
 import { StudyObj } from '../common/interfaces';
 import { editResultsAndLearnings } from '../../services/Api';
-import { lineBreak } from '../common/helpers/helpers';
+import { lineBreak, returnLimitMeta } from '../common/helpers/helpers';
 import { Label } from '../common/StyledComponents';
 import styled from 'styled-components';
 import { getResultsAndLearningsUrl } from '../../services/ApiCallStrings';
@@ -34,6 +34,8 @@ const TableWrapper = styled.div<{ canReadResandLearns: boolean }>`
 `;
 */
 
+const resultsAndLearningsLimit = 4096;
+
 type OverviewProps = {
     study: StudyObj;
     setHasChanged: any;
@@ -60,6 +62,9 @@ const Overview: React.FC<OverviewProps> = ({
     );
 
     const handleChange = (evt) => {
+        if (evt.target.value && evt.target.value.length > resultsAndLearningsLimit) {
+            return;
+        }
         setHasChanged(true);
         setResultsAndLearnings({ resultsAndLearnings: evt.target.value });
     };
@@ -111,6 +116,7 @@ const Overview: React.FC<OverviewProps> = ({
                             value={resultsAndLearnings.resultsAndLearnings}
                             autoComplete="off"
                             autoFocus
+                            meta={returnLimitMeta(resultsAndLearningsLimit, resultsAndLearnings.resultsAndLearnings)}
                         />
                     )}
                     <div style={{ display: 'flex' }}>

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -134,7 +134,7 @@ const PictureWrapper = styled.div<{ editMode: any }>`
 `;
 
 const limits = {
-    description: 500,
+    description: 512,
     name: 128,
     vendor: 128,
     wbsCode: 64
@@ -565,7 +565,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                 placeholder="Describe the study"
                                 multiline
                                 onChange={(e: any) => handleChange('description', e.target.value)}
-                                meta={returnLimitMeta(500, studyOnChange.description)}
+                                meta={returnLimitMeta(512, studyOnChange.description)}
                                 label="Description"
                                 style={{ height: '152px', resize: 'none' }}
                                 value={studyOnChange.description}

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -4,7 +4,15 @@ import styled from 'styled-components';
 import { Button, TextField, Icon, Tooltip, Menu, Typography, DotProgress } from '@equinor/eds-core-react';
 import CheckBox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import { dollar, visibility, visibility_off, business, settings, info_circle } from '@equinor/eds-icons';
+import {
+    dollar,
+    visibility,
+    visibility_off,
+    business,
+    settings,
+    info_circle,
+    warning_filled
+} from '@equinor/eds-icons';
 import { StudyObj } from '../common/interfaces';
 import { createStudy, updateStudy, closeStudy, validateWbsCode } from '../../services/Api';
 import AddImageAndCompressionContainer from '../common/upload/ImageDropzone';
@@ -12,6 +20,7 @@ import CustomLogoComponent from '../common/customComponents/CustomLogoComponent'
 import {
     checkIfRequiredFieldsAreNull,
     returnAllowedLengthOfString,
+    returnHelperText,
     returnLimitMeta,
     returnTextfieldTypeBasedOninput,
     truncate
@@ -29,7 +38,8 @@ const icons = {
     visibility_off,
     business,
     settings,
-    info_circle
+    info_circle,
+    warning_filled
 };
 Icon.add(icons);
 
@@ -445,6 +455,8 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                     data-cy="study_name"
                                     autoComplete="off"
                                     autoFocus
+                                    helperText={returnHelperText(studyOnChange.name.length, 50, 'study')}
+                                    helperIcon={<Icon name="warning_filled" title="Warning" />}
                                     inputIcon={
                                         <Tooltip
                                             title="The value must be between 3 and 128 characters long (A-Z)"

--- a/src/components/studyDetails/StudyComponentFull.tsx
+++ b/src/components/studyDetails/StudyComponentFull.tsx
@@ -455,7 +455,9 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                     data-cy="study_name"
                                     autoComplete="off"
                                     autoFocus
-                                    helperText={returnHelperText(studyOnChange.name.length, 50, 'study')}
+                                    helperText={
+                                        studyOnChange.name && returnHelperText(studyOnChange.name.length, 50, 'study')
+                                    }
                                     helperIcon={<Icon name="warning_filled" title="Warning" />}
                                     inputIcon={
                                         <Tooltip


### PR DESCRIPTION
If a user tries to create a study, sandbox or a dataset with a name over a certain length, a text will display recommending going for a shorter name

Closes #1148