### PR TITLE
fix: release notes tabs have now fixed position

### DIFF
--- a/src/components/releaseNotes/ReleaseNotes.tsx
+++ b/src/components/releaseNotes/ReleaseNotes.tsx
@@ -69,14 +69,19 @@ const ReleaseNotes = () => {
 
     return (
         <OuterWrapper>
+            <Tabs
+                activeTab={activeTab}
+                variant="fullWidth"
+                onChange={(e: any) => setActiveTab(e)}
+                style={{ position: 'fixed', backgroundColor: '#FFFFFF' }}
+            >
+                <Tabs.List style={divStyle}>
+                    <Tabs.Tab style={{ marginLeft: '32px' }}>Web App</Tabs.Tab>
+                    <Tabs.Tab style={{ marginRight: '32px' }}>Api</Tabs.Tab>
+                </Tabs.List>
+            </Tabs>
             <Wrapper>
-                <Tabs activeTab={activeTab} variant="fullWidth" onChange={(e: any) => setActiveTab(e)}>
-                    <Tabs.List style={divStyle}>
-                        <Tabs.Tab style={{ marginLeft: '32px' }}>Web App</Tabs.Tab>
-                        <Tabs.Tab style={{ marginRight: '32px' }}>Api</Tabs.Tab>
-                    </Tabs.List>
-                </Tabs>
-                <div style={{ margin: '32px 32px 32px 32px' }}>{changeComponent()}</div>
+                <div style={{ margin: '80px 32px 32px 32px' }}>{changeComponent()}</div>
             </Wrapper>
         </OuterWrapper>
     );


### PR DESCRIPTION
Makes it easier to compare api and web changes when you can switch back and forth without scrolling up

Closes #957