### PR TITLE
fix: disable resize of results and learnings textfield

### DIFF
--- a/src/components/studyDetails/Overview.tsx
+++ b/src/components/studyDetails/Overview.tsx
@@ -112,7 +112,7 @@ const Overview: React.FC<OverviewProps> = ({
                             data-cy="results_and_learnings"
                             multiline
                             onChange={handleChange}
-                            style={{ margin: 'auto', marginLeft: '0', height: '300px' }}
+                            style={{ margin: 'auto', marginLeft: '0', height: '300px', resize: 'none' }}
                             value={resultsAndLearnings.resultsAndLearnings}
                             autoComplete="off"
                             autoFocus


### PR DESCRIPTION
This could be dragged so the page looked very weird. Easiest to disable it

Closes #1154