### PR TITLE
fix: issue with disabled save button on vm rules

### DIFF
--- a/src/components/sandbox/components/VmConfig.tsx
+++ b/src/components/sandbox/components/VmConfig.tsx
@@ -48,6 +48,7 @@ const VmConfig: React.FC<VmConfigProps> = ({
     const [sizes, setSizes] = useState<SizeObj | undefined>(undefined);
     const [disks, setDisks] = useState<DropdownObj | undefined>(undefined);
     const [os, setOs] = useState<OperatingSystemObj | undefined>(undefined);
+    const [hasChangedVmRules, setHasChangedVmRules] = useState<any>([]);
     const [isSubscribed, setIsSubscribed] = useState<boolean>(true);
     const vmsReponse = useFetchUrl(getVmsForSandboxUrl(sandbox.id), setVms);
     const [vmSaved, setVmSaved] = useState<Boolean>(false);
@@ -156,6 +157,8 @@ const VmConfig: React.FC<VmConfigProps> = ({
                         setUpdateCache={setUpdateCache}
                         updateCache={updateCache}
                         setVmSaved={setVmSaved}
+                        hasChangedVmRules={hasChangedVmRules}
+                        setHasChangedVmRules={setHasChangedVmRules}
                     />
                 );
         }

--- a/src/components/sandbox/components/VmDetails.tsx
+++ b/src/components/sandbox/components/VmDetails.tsx
@@ -97,7 +97,6 @@ const VmDetails: React.FC<VmDetailsProps> = ({
     const [clientIp, setClientIp] = useState<string>('');
     const [hasChanged, setHasChanged] = useState<boolean>(false);
     const [outboundRuleChanged, setOutboundRuleChanged] = useState<boolean>(false);
-    // const [hasChangedVmRules, setHasChangedVmRules] = useState<any>([]);
     const [inputError, setInputError] = useState<string>(inputErrors.notAllFieldsFilled);
     const studyId = getStudyId();
     let keyCount: number = 0;

--- a/src/components/sandbox/components/VmDetails.tsx
+++ b/src/components/sandbox/components/VmDetails.tsx
@@ -44,6 +44,8 @@ type VmDetailsProps = {
     setUpdateCache: any;
     updateCache: any;
     setVmSaved: any;
+    hasChangedVmRules: any;
+    setHasChangedVmRules: any;
 };
 
 const ipMethod = [
@@ -88,12 +90,14 @@ const VmDetails: React.FC<VmDetailsProps> = ({
     setUpdateCache,
     updateCache,
     getResources,
-    setVmSaved
+    setVmSaved,
+    hasChangedVmRules,
+    setHasChangedVmRules
 }) => {
     const [clientIp, setClientIp] = useState<string>('');
     const [hasChanged, setHasChanged] = useState<boolean>(false);
     const [outboundRuleChanged, setOutboundRuleChanged] = useState<boolean>(false);
-    const [hasChangedVmRules, setHasChangedVmRules] = useState<any>([]);
+    // const [hasChangedVmRules, setHasChangedVmRules] = useState<any>([]);
     const [inputError, setInputError] = useState<string>(inputErrors.notAllFieldsFilled);
     const studyId = getStudyId();
     let keyCount: number = 0;


### PR DESCRIPTION
If the user entered a valid rule and went back and forth between vm tabs, it will be disabled until the user did a change

Closes #1212