### PR TITLE
fix: stop disabeling create button with invalid vm name

### DIFF
--- a/src/components/common/helpers/sandboxHelpers.tsx
+++ b/src/components/common/helpers/sandboxHelpers.tsx
@@ -33,8 +33,7 @@ export const validateUserInput = (
         vm.name !== '' &&
         vm.operatingSystem !== '' &&
         vm.size !== '' &&
-        usernameIsValid &&
-        validateVmName(vm.name)
+        usernameIsValid
     ) {
         return true;
     }

--- a/src/components/common/helpers/sandboxHelpers.tsx
+++ b/src/components/common/helpers/sandboxHelpers.tsx
@@ -33,7 +33,8 @@ export const validateUserInput = (
         vm.name !== '' &&
         vm.operatingSystem !== '' &&
         vm.size !== '' &&
-        usernameIsValid
+        usernameIsValid &&
+        validateVmName(vm.name)
     ) {
         return true;
     }
@@ -83,6 +84,16 @@ export const returnUsernameVariant = (vmUsername: string, usernameIsValid: boole
         return 'default';
     }
     if (usernameIsValid) {
+        return 'success';
+    }
+    return 'error';
+};
+
+export const returnVMnameVariant = (vmName: string) => {
+    if (vmName === '' || vmName === undefined) {
+        return 'default';
+    }
+    if (validateVmName(vmName)) {
         return 'success';
     }
     return 'error';

--- a/src/components/sandbox/components/AddNewVm.tsx
+++ b/src/components/sandbox/components/AddNewVm.tsx
@@ -22,7 +22,8 @@ import {
     returnKeyOfDisplayValue,
     validateUsername,
     filterOs,
-    returnDisplayName
+    returnDisplayName,
+    returnVMnameVariant
 } from '../../common/helpers/sandboxHelpers';
 import CoreDevDropdown from '../../common/customComponents/Dropdown';
 import { createVirtualMachine, getVmName, getVirtualMachineCost } from '../../../services/Api';
@@ -288,6 +289,7 @@ const AddNewVm: React.FC<AddNewVmProps> = ({
                     autoComplete="off"
                     label="Name"
                     meta={returnLimitMeta(20, vm.name)}
+                    variant={returnVMnameVariant(vm.name)}
                     data-cy="vm_name"
                     inputIcon={
                         <Tooltip title="The value must be between 3 and 20 characters long" placement="right">


### PR DESCRIPTION
The UI already tells the users what the vm name will be, regardless of what they type

Closes #1230