### PR TITLE
fix: issue with deleting vm with enter button

### DIFF
--- a/src/components/sandbox/components/AddNewVm.tsx
+++ b/src/components/sandbox/components/AddNewVm.tsx
@@ -154,8 +154,6 @@ const AddNewVm: React.FC<AddNewVmProps> = React.memo(
         const [displayRecommendedOs, setDisplayRecommendedOs] = useState<boolean>(false);
         const [loading, setLoading] = useState<boolean>(false);
 
-        console.log('add new vm rerender');
-
         useEffect(() => {
             const timeoutId = setTimeout(() => {
                 calculateVmName(vm.name);

--- a/src/components/sandbox/components/VmProperties.tsx
+++ b/src/components/sandbox/components/VmProperties.tsx
@@ -77,12 +77,12 @@ const VmProperties: React.FC<VmPropertiesProps> = ({
     const deleteVm = (): void => {
         setUpdateCache({ ...updateCache, [getVmsForSandboxUrl(sandboxId)]: true });
         setActiveTab(0);
-        const currentVms: any = [...vms];
-        currentVms.splice(vms.indexOf(vmProperties), 1);
-        setVms(currentVms);
         deleteVirtualMachine(vmProperties.id).then((result: any) => {
             if (result && !result.message) {
                 setCallGetResources(true);
+                const currentVms: any = [...vms];
+                currentVms.splice(vms.indexOf(vmProperties), 1);
+                setVms(currentVms);
             }
         });
     };


### PR DESCRIPTION
When hitting enter instead of clicking the delete button, the VM would reappear

Closes #1322