### PR TITLE
fix: clicking on breadcrum for dataset/sandbox name would redirect to…

### DIFF
--- a/src/components/common/customComponents/infoDisplayComponents/BreadcrumbTruncate.tsx
+++ b/src/components/common/customComponents/infoDisplayComponents/BreadcrumbTruncate.tsx
@@ -14,7 +14,7 @@ type BreadcrumbTruncateProps = {
 const BreadcrumbTruncate: React.FC<BreadcrumbTruncateProps> = ({
     breadcrumbText,
     truncateLength = defaultLength,
-    link = '',
+    link = window.location.pathname,
     datacy
 }) => {
     const history = useHistory();


### PR DESCRIPTION
… main page

Should not go anywhere. There is already a link to main page on the topbar

Closes #1348
Closes #1347