### PR TITLE
fix: display search tip with less than 3 characters

### DIFF
--- a/src/components/studyDetails/ParticipantComponent.tsx
+++ b/src/components/studyDetails/ParticipantComponent.tsx
@@ -14,6 +14,7 @@ import { UserConfig } from '../../index';
 import { useHistory } from 'react-router-dom';
 import { getStudyByIdUrl } from '../../services/ApiCallStrings';
 import { getStudyId } from 'utils/CommonUtil';
+import { MinimumCharactersToSearch } from './StudyTextSnippets';
 
 const Wrapper = styled.div`
     display: grid;
@@ -48,7 +49,7 @@ const ParicipantComponent: React.FC<ParicipantComponentProps> = ({ study, setStu
     const [participantNotSelected, setParticipantNotSelected] = useState<boolean>(true);
     const [roleNotSelected, setRoleNotSelected] = useState<boolean>(true);
     const [selectedParticipant, setSelectedParticipant] = useState<ParticipantObj | undefined>();
-    const [text, setText] = useState<string>('Type minimum three characters to search');
+    const [text, setText] = useState<string>(MinimumCharactersToSearch);
     const [role, setRole] = useState<string>('');
     const rolesResponse = useFetchUrl('studies/' + studyId + '/availableroles', setRoles);
     const [isSubscribed, setIsSubscribed] = useState<boolean>(true);
@@ -92,7 +93,7 @@ const ParicipantComponent: React.FC<ParicipantComponentProps> = ({ study, setStu
                 delay: 500 // ms
             });
         } else {
-            callback([]);
+            callback([{ label: MinimumCharactersToSearch, isDisabled: true }]);
         }
     };
 

--- a/src/components/studyDetails/StudyTextSnippets.ts
+++ b/src/components/studyDetails/StudyTextSnippets.ts
@@ -1,0 +1,2 @@
+export const MinimumCharactersToSearch = 'Type minimum three characters to search';
+export const NoAccessToAddParticipants = 'You do not have access to add participants';


### PR DESCRIPTION
Before it would say "no options" when for instance writing 2 characters,
and the initial tip is no longer displayed since you started typing

Closes #1264