### PR TITLE
fix: issue with deleting sandbox with unsaved changes

### DIFF
--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -164,6 +164,7 @@ const Sandbox: React.FC<SandboxProps> = () => {
                                 vmsWithOpenInternet={vmsWithOpenInternet}
                                 makeAvailableInProgress={makeAvailableInProgress}
                                 setMakeAvailableInProgress={setMakeAvailableInProgress}
+                                setHasChanged={setHasChanged}
                             />
                             {returnStepComponent()}
                             {(step === 0 || step === 1) && (

--- a/src/components/sandbox/StepBar.tsx
+++ b/src/components/sandbox/StepBar.tsx
@@ -66,7 +66,8 @@ type StepBarProps = {
     controller: AbortController;
     vmsWithOpenInternet: any;
     setMakeAvailableInProgress: any;
-    makeAvailableInProgress: any;
+    makeAvailableInProgress: boolean;
+    setHasChanged: any;
 };
 
 const getSteps = () => {
@@ -102,7 +103,8 @@ const StepBar: React.FC<StepBarProps> = ({
     controller,
     vmsWithOpenInternet,
     setMakeAvailableInProgress,
-    makeAvailableInProgress
+    makeAvailableInProgress,
+    setHasChanged
 }) => {
     const history = useHistory();
     const steps = getSteps();
@@ -177,6 +179,7 @@ const StepBar: React.FC<StepBarProps> = ({
     };
 
     const deleteThisSandbox = (): void => {
+        setHasChanged(false);
         setDeleteSandboxInProgress(true);
         setUserClickedDelete(false);
         setLoading(true);

--- a/src/tests/component_tests/sandbox/Stepbar.test.tsx
+++ b/src/tests/component_tests/sandbox/Stepbar.test.tsx
@@ -27,7 +27,8 @@ test('renders stepbar component without permissions', async () => {
                 controller={new AbortController()}
                 vmsWithOpenInternet={mockFunc}
                 setMakeAvailableInProgress={mockFunc}
-                makeAvailableInProgress={mockFunc}
+                makeAvailableInProgress={false}
+                setHasChanged={mockFunc}
             />
         </Router>
     );
@@ -63,7 +64,8 @@ test('renders stepbar component with permissions', async () => {
                 controller={new AbortController()}
                 vmsWithOpenInternet={mockFunc}
                 setMakeAvailableInProgress={mockFunc}
-                makeAvailableInProgress={mockFunc}
+                makeAvailableInProgress={false}
+                setHasChanged={mockFunc}
             />
         </Router>
     );


### PR DESCRIPTION
The unsaved changes dialog would pop up if there was any and you tried to delete the sandbox. This could result in weird side effects if you clicked stay after deleting sandbox

Closes #1437