### PR TITLE
fix: remove interfering save shortcut

### DIFF
--- a/src/components/studyDetails/Overview.tsx
+++ b/src/components/studyDetails/Overview.tsx
@@ -93,7 +93,7 @@ const Overview: React.FC<OverviewProps> = ({
         }
     };
 
-    useKeyEvents(handleCancel, handleSave, editMode);
+    useKeyEvents(handleCancel, undefined, editMode);
 
     return (
         <Wrapper>

--- a/src/components/studyDetails/StudyFull.tsx
+++ b/src/components/studyDetails/StudyFull.tsx
@@ -348,7 +348,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
         });
     };
 
-    useKeyEvents(handleCancel, handleSave, editMode && !userClickedDelete);
+    useKeyEvents(handleCancel, undefined, editMode && !userClickedDelete);
 
     return (
         <div
@@ -415,10 +415,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
                                     }
                                     helperIcon={<Icon name="warning_filled" title="Warning" />}
                                     inputIcon={
-                                        <Tooltip
-                                            title={StudyTextFieldsTooltip.Name}
-                                            placement="right"
-                                        >
+                                        <Tooltip title={StudyTextFieldsTooltip.Name} placement="right">
                                             <Icon name="info_circle" />
                                         </Tooltip>
                                     }


### PR DESCRIPTION
Removed an issue where you can create lineshifts with enter since it instead saves. This is was valid for study description and results and learnings

Closes #1458
Closes #1459