### PR TITLE
refactor: add sandbox to state management

### DIFF
--- a/src/components/common/helpers/sandboxHelpers.tsx
+++ b/src/components/common/helpers/sandboxHelpers.tsx
@@ -212,7 +212,8 @@ export const allResourcesStatusOkAndAtleastOneVm = (
     setAllResourcesOk,
     sandbox,
     setNewCostanalysisLink,
-    setSandbox
+    dispatch: any,
+    setSandboxInStore: any
 ) => {
     let res = true;
     if (!resourcesIn || !Array.isArray(resourcesIn)) {
@@ -231,7 +232,7 @@ export const allResourcesStatusOkAndAtleastOneVm = (
             }
         }
         if (resource.type === resourceType.resourceGroup && sandbox.linkToCostAnalysis === null) {
-            getCostAnalysisLinkToSandbox(sandbox, setNewCostanalysisLink, setSandbox);
+            getCostAnalysisLinkToSandbox(sandbox, setNewCostanalysisLink, dispatch, setSandboxInStore);
         }
     });
     setAnyVmWithOpenInternet(!noOpenInternet);
@@ -239,11 +240,16 @@ export const allResourcesStatusOkAndAtleastOneVm = (
     setAllResourcesOk(res && hasVm && noOpenInternet);
 };
 
-const getCostAnalysisLinkToSandbox = (sandbox: SandboxObj, setNewCostanalysisLink: any, setSandbox: any) => {
+const getCostAnalysisLinkToSandbox = (
+    sandbox: SandboxObj,
+    setNewCostanalysisLink: any,
+    dispatch: any,
+    setSandboxInStore: any
+) => {
     getSandboxCostAnalysis(sandbox.id).then((result: any) => {
         if (result && !result.message) {
             setNewCostanalysisLink(result);
-            setSandbox({ ...sandbox, linkToCostAnalysis: result });
+            dispatch(setSandboxInStore({ sandbox, linkToCostAnalysis: result }));
         }
     });
 };

--- a/src/components/common/hooks/useFetchUrl.tsx
+++ b/src/components/common/hooks/useFetchUrl.tsx
@@ -4,7 +4,15 @@ import { apiRequestWithToken } from '../../../auth/AuthFunctions';
 
 const cache = {};
 
-const useFetchUrl = (url: string, setter, condition?, controller?, shouldCache = true) => {
+const useFetchUrl = (
+    url: string,
+    setter: any,
+    condition?,
+    controller?,
+    shouldCache = true,
+    dispatch: any = undefined,
+    actionCreatorWithPayload: any = undefined
+) => {
     const { updateCache, setUpdateCache } = useContext(UpdateCache);
     const [isSubscribed, setIsSubscribed] = useState<boolean>(true);
     const [loading, setLoading] = useState<boolean>(false);
@@ -29,11 +37,21 @@ const useFetchUrl = (url: string, setter, condition?, controller?, shouldCache =
                         if (url) {
                             cache[url] = result;
                         }
-                        if (setUpdateCache) {
-                            setUpdateCache({ ...updateCache, [url]: false });
-                        }
+
                         setIntialValue(result);
-                        setter(result);
+
+                        if (setter !== undefined) {
+                            setter(result);
+                        }
+
+                        if (dispatch !== undefined && actionCreatorWithPayload !== undefined) {
+                            dispatch(actionCreatorWithPayload(result));
+                        } else {
+                            // eslint-disable-next-line no-lonely-if
+                            if (setUpdateCache) {
+                                setUpdateCache({ ...updateCache, [url]: false });
+                            }
+                        }
                     } else {
                         setNotFound(true);
                     }

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -55,6 +55,7 @@ const Sandbox: React.FC<SandboxProps> = () => {
         return () => {
             controller.abort();
             controller = new AbortController();
+            dispatch(setSandboxInStore({}));
         };
     }, []);
 

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -2,20 +2,18 @@ import React, { useState, useContext, useEffect } from 'react';
 import StepBar from './StepBar';
 import SandboxConfig from './SandboxConfig';
 import Execution from './Execution';
-import { SandboxObj } from '../common/interfaces';
 import VmConfig from './components/VmConfig';
 import LoadingFull from '../common/LoadingFullscreen';
 import styled from 'styled-components';
 import { UpdateCache } from '../../App';
 import useFetchUrl from '../common/hooks/useFetchUrl';
-import { getSandboxByIdUrl } from '../../services/ApiCallStrings';
 import NotFound from '../common/informationalComponents/NotFound';
 import { getResourcesList } from '../../services/Api';
 import { getStudyId, getSandboxId } from '../../utils/CommonUtil';
 import Prompt from 'components/common/Prompt';
 import { useDispatch, useSelector } from 'react-redux';
-import { setCallResources } from 'store/sandboxes/sandboxesSlice';
-import getCallResourcesStatus from 'store/sandboxes/sanboxesSelectors';
+import { setCallResources, setSandboxInStore } from 'store/sandboxes/sandboxesSlice';
+import { getCallResourcesStatus, getSandboxFromStore } from 'store/sandboxes/sanboxesSelectors';
 import { setResourcesInStore } from 'store/resources/resourcesSlice';
 
 const Wrapper = styled.div`
@@ -33,42 +31,25 @@ const Sandbox: React.FC<SandboxProps> = () => {
     const studyId = getStudyId();
     const sandboxId = getSandboxId();
     const { updateCache, setUpdateCache } = useContext(UpdateCache);
-    const [sandbox, setSandbox] = useState<SandboxObj>({
-        deleted: false,
-        region: '',
-        resources: [],
-        datasets: [],
-        studyId: '',
-        technicalContactEmail: '',
-        technicalContactName: '',
-        name: '',
-        template: '',
-        id: sandboxId,
-        currentPhase: undefined,
-        linkToCostAnalysis: '',
-        studyName: '',
-        restrictionDisplayText: '',
-        permissions: {
-            delete: false,
-            editInboundRules: false,
-            openInternet: false,
-            update: false,
-            increasePhase: false
-        }
-    });
 
-    const SandboxResponse = useFetchUrl('sandboxes/' + sandboxId, setSandbox, undefined, undefined, false);
+    const dispatch = useDispatch();
+    const SandboxResponse = useFetchUrl(
+        'sandboxes/' + sandboxId,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        dispatch,
+        setSandboxInStore
+    );
+
+    const sandbox = useSelector(getSandboxFromStore());
     const [deleteSandboxInProgress, setDeleteSandboxInProgress] = useState<boolean>(false);
     const [vmsWithOpenInternet, setVmsWithOpenInternet] = useState<boolean>(false);
     const [makeAvailableInProgress, setMakeAvailableInProgress] = useState<boolean>(false);
-    const [step, setStep] = useState<number | undefined>(
-        (SandboxResponse.cache[getSandboxByIdUrl(sandboxId)] &&
-            SandboxResponse.cache[getSandboxByIdUrl(sandboxId)].currentPhase) ||
-            undefined
-    );
+    const [step, setStep] = useState<number | undefined>((sandbox && sandbox.currentPhase) || undefined);
     const [hasChanged, setHasChanged] = useState<boolean>(false);
     const callGetResources = useSelector(getCallResourcesStatus());
-    const dispatch = useDispatch();
 
     useEffect(() => {
         return () => {
@@ -85,11 +66,8 @@ const Sandbox: React.FC<SandboxProps> = () => {
     }, [callGetResources]);
 
     useEffect(() => {
-        if (
-            SandboxResponse.cache[getSandboxByIdUrl(sandboxId)] &&
-            SandboxResponse.cache[getSandboxByIdUrl(sandboxId)].currentPhase
-        ) {
-            setNewPhase(SandboxResponse.cache[getSandboxByIdUrl(sandboxId)].currentPhase);
+        if (sandbox && sandbox.currentPhase) {
+            setNewPhase(sandbox.currentPhase);
         } else if (sandbox.currentPhase !== undefined && !SandboxResponse.loading) {
             setNewPhase(sandbox.currentPhase);
         }
@@ -106,14 +84,14 @@ const Sandbox: React.FC<SandboxProps> = () => {
     };
 
     const setNewPhase = (phase: any) => {
-        if (SandboxResponse.cache[getSandboxByIdUrl(sandboxId)]) {
+        if (sandbox) {
             setStep(phase);
-            SandboxResponse.cache[getSandboxByIdUrl(sandboxId)].currentPhase = phase;
+            dispatch(setSandboxInStore({ ...sandbox, currentPhase: phase }));
         }
     };
 
     const setNewCostanalysisLink = (link: any) => {
-        SandboxResponse.cache[getSandboxByIdUrl(sandboxId)].linkToCostAnalysis = link;
+        sandbox.linkToCostAnalysis = link;
     };
 
     const returnStepComponent = () => {
@@ -129,7 +107,6 @@ const Sandbox: React.FC<SandboxProps> = () => {
                         setUpdateCache={setUpdateCache}
                         updateCache={updateCache}
                         sandbox={sandbox}
-                        setSandbox={setSandbox}
                         controller={controller}
                     />
                 );
@@ -147,14 +124,10 @@ const Sandbox: React.FC<SandboxProps> = () => {
                         )}
                         <Wrapper>
                             <StepBar
-                                sandbox={sandbox}
-                                setSandbox={setSandbox}
                                 step={step}
                                 setStep={setStep}
                                 studyId={studyId}
                                 sandboxId={sandboxId}
-                                setUpdateCache={setUpdateCache}
-                                updateCache={updateCache}
                                 setLoading={SandboxResponse.setLoading}
                                 setNewPhase={setNewPhase}
                                 setDeleteSandboxInProgress={setDeleteSandboxInProgress}
@@ -164,6 +137,8 @@ const Sandbox: React.FC<SandboxProps> = () => {
                                 makeAvailableInProgress={makeAvailableInProgress}
                                 setMakeAvailableInProgress={setMakeAvailableInProgress}
                                 setHasChanged={setHasChanged}
+                                updateCache={updateCache}
+                                setUpdateCache={setUpdateCache}
                             />
                             {returnStepComponent()}
                             {(step === 0 || step === 1) && (

--- a/src/components/sandbox/Sandbox.tsx
+++ b/src/components/sandbox/Sandbox.tsx
@@ -143,7 +143,6 @@ const Sandbox: React.FC<SandboxProps> = () => {
                             {returnStepComponent()}
                             {(step === 0 || step === 1) && (
                                 <VmConfig
-                                    sandbox={sandbox}
                                     setUpdateCache={setUpdateCache}
                                     updateCache={updateCache}
                                     controller={controller}

--- a/src/components/sandbox/SandboxConfig.tsx
+++ b/src/components/sandbox/SandboxConfig.tsx
@@ -37,7 +37,6 @@ type SandboxConfigProps = {
     sandboxId: string;
     updateCache: any;
     setUpdateCache: any;
-    setSandbox: any;
     sandbox: SandboxObj;
     controller: AbortController;
 };
@@ -46,7 +45,6 @@ const SandboxConfig: React.FC<SandboxConfigProps> = ({
     sandboxId,
     updateCache,
     setUpdateCache,
-    setSandbox,
     sandbox,
     controller
 }) => {
@@ -57,9 +55,8 @@ const SandboxConfig: React.FC<SandboxConfigProps> = ({
                     sandboxId={sandboxId}
                     updateCache={updateCache}
                     setUpdateCache={setUpdateCache}
-                    setSandbox={setSandbox}
-                    sandbox={sandbox}
                     controller={controller}
+                    sandbox={sandbox}
                 />
                 <PolictyComponentWrapper>
                     <Policy displayCheckbox sandbox={sandbox} />

--- a/src/components/sandbox/StepBar.tsx
+++ b/src/components/sandbox/StepBar.tsx
@@ -188,6 +188,7 @@ const StepBar: React.FC<StepBarProps> = ({
                 setDeleteSandboxInProgress(false);
             }
             history.push('/studies/' + studyId);
+            dispatch(setSandboxInStore({}));
         });
     };
 

--- a/src/components/sandbox/StepBar.tsx
+++ b/src/components/sandbox/StepBar.tsx
@@ -188,7 +188,6 @@ const StepBar: React.FC<StepBarProps> = ({
                 setDeleteSandboxInProgress(false);
             }
             history.push('/studies/' + studyId);
-            dispatch(setSandboxInStore({}));
         });
     };
 

--- a/src/components/sandbox/StepBar.tsx
+++ b/src/components/sandbox/StepBar.tsx
@@ -22,8 +22,6 @@ import { setResourcesInStore } from 'store/resources/resourcesSlice';
 import { getSandboxFromStore } from 'store/sandboxes/sanboxesSelectors';
 import { setSandboxInStore } from 'store/sandboxes/sandboxesSlice';
 
-const set = require('lodash/set');
-
 const Wrapper = styled.div`
     display: grid;
     grid-template-rows: 64px 1fr;

--- a/src/components/sandbox/components/AddNewVm.tsx
+++ b/src/components/sandbox/components/AddNewVm.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../common/helpers/sandboxHelpers';
 import CoreDevDropdown from '../../common/customComponents/Dropdown';
 import { createVirtualMachine, getVmName, getVirtualMachineCost } from '../../../services/Api';
-import { SandboxObj, DropdownObj, SizeObj, VmObj, CalculateNameObj } from '../../common/interfaces';
+import { DropdownObj, SizeObj, VmObj, CalculateNameObj } from '../../common/interfaces';
 import styled from 'styled-components';
 import { getVmsForSandboxUrl } from '../../../services/ApiCallStrings';
 import useKeyEvents from '../../common/hooks/useKeyEvents';
@@ -36,7 +36,8 @@ import Password from 'components/common/customComponents/Password';
 import HelperTexts from 'components/common/constants/HelperTexts';
 import { VmTextFieldsTooltip } from 'components/common/constants/TooltipTitleTexts';
 import { setCallResources } from 'store/sandboxes/sandboxesSlice';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { getSandboxFromStore } from 'store/sandboxes/sanboxesSelectors';
 
 const Wrapper = styled.div`
     height: auto;
@@ -83,7 +84,6 @@ const UnstyledList = styled.ul`
 `;
 
 type AddNewVmProps = {
-    sandbox: SandboxObj;
     setVms: any;
     vms: any;
     setActiveTab: any;
@@ -123,7 +123,6 @@ const width = '400px';
 
 const AddNewVm: React.FC<AddNewVmProps> = React.memo(
     ({
-        sandbox,
         setVms,
         vms,
         sizes,
@@ -141,6 +140,7 @@ const AddNewVm: React.FC<AddNewVmProps> = React.memo(
         setHasChanged
     }) => {
         const sandboxId = window.location.pathname.split('/')[4];
+        const sandbox = useSelector(getSandboxFromStore());
         const [actualVmName, setActualVmName] = useState<string>('');
         const [usernameIsValid, setUsernameIsValid] = useState<boolean | undefined>(undefined);
         const [vmEstimatedCost, setVmEstimatedCost] = useState<any>();

--- a/src/components/sandbox/components/Dataset.tsx
+++ b/src/components/sandbox/components/Dataset.tsx
@@ -8,13 +8,14 @@ import useFetchUrl from '../../common/hooks/useFetchUrl';
 import {
     getAvailableDatasetsUrl,
     getDatasetsInSandboxUrl,
-    getSandboxByIdUrl,
     getStudyByIdUrl
 } from '../../../services/ApiCallStrings';
 import '../../../styles/Table.scss';
 import { getStudyId } from '../../../utils/CommonUtil';
 import { truncate } from 'components/common/helpers/helpers';
 import { returnTooltipTextDataset } from '../../common/helpers/sandboxHelpers';
+import { useDispatch } from 'react-redux';
+import { setSandboxInStore } from 'store/sandboxes/sandboxesSlice';
 
 const SatusWrapper = styled.div`
     display: flex;
@@ -23,23 +24,16 @@ const SatusWrapper = styled.div`
 
 const { Body, Row, Cell, Head } = Table;
 
-type datasetProps = {
+type DatasetProps = {
     sandboxId: string;
     updateCache: any;
     setUpdateCache: any;
-    setSandbox: any;
     sandbox: SandboxObj;
     controller: AbortController;
 };
 
-const Dataset: React.FC<datasetProps> = ({
-    sandboxId,
-    updateCache,
-    setUpdateCache,
-    setSandbox,
-    sandbox,
-    controller
-}) => {
+const Dataset: React.FC<DatasetProps> = ({ sandboxId, updateCache, setUpdateCache, sandbox, controller }) => {
+    const dispatch = useDispatch();
     const studyId = getStudyId();
     const [availableDatasets, setAvailableDatasets] = useState<any>([]);
     const availableDatasetsResponse = useFetchUrl(
@@ -58,22 +52,22 @@ const Dataset: React.FC<datasetProps> = ({
             ...updateCache,
             [getStudyByIdUrl(studyId)]: true,
             [getDatasetsInSandboxUrl(sandboxId)]: true,
-            [getAvailableDatasetsUrl(sandboxId)]: true,
-            [getSandboxByIdUrl(sandboxId)]: true
+            [getAvailableDatasetsUrl(sandboxId)]: true
         });
+
         if (evt.target.checked) {
             putDatasetForSandbox(sandboxId, dataset.datasetId).then((result: any) => {
                 setAddDatasetInprogress({ [dataset.datasetId]: false });
                 if (result && result.message) {
                     console.log('Err');
                 } else {
-                    const tempDatasets: any = sandbox.datasets;
-                    tempDatasets.push(dataset.datasetId);
-                    setSandbox({
-                        ...sandbox,
-                        datasets: tempDatasets,
-                        restrictionDisplayText: result.restrictionDisplayText
-                    });
+                    dispatch(
+                        setSandboxInStore({
+                            ...sandbox,
+                            datasets: { ...sandbox.datasets, dataset },
+                            restrictionDisplayText: result.restrictionDisplayText
+                        })
+                    );
                 }
             });
         } else {
@@ -82,13 +76,13 @@ const Dataset: React.FC<datasetProps> = ({
                 if (result && result.message) {
                     console.log('Err');
                 } else {
-                    const tempDatasets: any = sandbox.datasets;
-                    tempDatasets.splice(tempDatasets.indexOf(dataset.datasetId), 1);
-                    setSandbox({
-                        ...sandbox,
-                        datasets: tempDatasets,
-                        restrictionDisplayText: result.restrictionDisplayText
-                    });
+                    dispatch(
+                        setSandboxInStore({
+                            ...sandbox,
+                            datasets: Object.values(sandbox.datasets).filter((d) => d.id === dataset.datasetId),
+                            restrictionDisplayText: result.restrictionDisplayText
+                        })
+                    );
                 }
             });
         }

--- a/src/components/sandbox/components/Policy.tsx
+++ b/src/components/sandbox/components/Policy.tsx
@@ -11,7 +11,7 @@ type DatasetProps = {
     sandbox: SandboxObj;
 };
 
-const Dataset: React.FC<DatasetProps> = ({ displayCheckbox, sandbox }) => {
+const Policy: React.FC<DatasetProps> = ({ displayCheckbox, sandbox }) => {
     return (
         <>
             <Table style={{ width: '100%', marginBottom: '24px', marginRight: '86px' }}>
@@ -35,8 +35,8 @@ const Dataset: React.FC<DatasetProps> = ({ displayCheckbox, sandbox }) => {
     );
 };
 
-Dataset.defaultProps = {
+Policy.defaultProps = {
     displayCheckbox: undefined
 };
 
-export default Dataset;
+export default Policy;

--- a/src/components/sandbox/components/VmConfig.tsx
+++ b/src/components/sandbox/components/VmConfig.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Tabs } from '@equinor/eds-core-react';
 import AddNewVm from './AddNewVm';
-import { SandboxObj, SizeObj, DropdownObj, OperatingSystemObj, VmObj } from '../../common/interfaces';
+import { SizeObj, DropdownObj, OperatingSystemObj, VmObj } from '../../common/interfaces';
 import {
     getVirtualMachineDisks,
     getVirtualMachineSizes,
@@ -11,9 +11,10 @@ import VmDetails from './VmDetails';
 import useFetchUrl from '../../common/hooks/useFetchUrl';
 import { getVmsForSandboxUrl } from '../../../services/ApiCallStrings';
 import { checkIfAnyVmsHasOpenInternet } from 'components/common/helpers/sandboxHelpers';
+import { useSelector } from 'react-redux';
+import { getSandboxFromStore } from 'store/sandboxes/sanboxesSelectors';
 
 type VmConfigProps = {
-    sandbox: SandboxObj;
     setUpdateCache: any;
     updateCache: any;
     controller: AbortController;
@@ -22,7 +23,6 @@ type VmConfigProps = {
 };
 
 const VmConfig: React.FC<VmConfigProps> = ({
-    sandbox,
     setUpdateCache,
     updateCache,
     controller,
@@ -30,6 +30,7 @@ const VmConfig: React.FC<VmConfigProps> = ({
     setHasChanged
 }) => {
     const [activeTab, setActiveTab] = useState<number>(0);
+    const sandbox = useSelector(getSandboxFromStore());
     const [vms, setVms] = useState<any>([]);
     const [sizes, setSizes] = useState<SizeObj | undefined>(undefined);
     const [disks, setDisks] = useState<DropdownObj | undefined>(undefined);
@@ -115,7 +116,6 @@ const VmConfig: React.FC<VmConfigProps> = ({
             case 0:
                 return showAddNewVm ? (
                     <AddNewVm
-                        sandbox={sandbox}
                         setVms={setVms}
                         vms={vms}
                         sizes={sizes}

--- a/src/store/sandboxes/sanboxesSelectors.ts
+++ b/src/store/sandboxes/sanboxesSelectors.ts
@@ -1,11 +1,12 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from 'store';
 
-export const getCallResourcesStatus = () => createSelector(
-     [(state:RootState) => state.sandboxes.callGetResources],
-    (callGetResources) => {
+export const getCallResourcesStatus = () =>
+    createSelector([(state: RootState) => state.sandboxes.callGetResources], (callGetResources) => {
         return callGetResources;
-    }
-);
+    });
 
-export default getCallResourcesStatus;
+export const getSandboxFromStore = () =>
+    createSelector([(state: RootState) => state.sandboxes.sandbox], (sandbox) => {
+        return sandbox;
+    });

--- a/src/store/sandboxes/sandboxesSlice.ts
+++ b/src/store/sandboxes/sandboxesSlice.ts
@@ -1,11 +1,38 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { SandboxObj } from 'components/common/interfaces';
 
 interface SandboxesState {
     callGetResources: boolean;
+    sandbox: SandboxObj;
 }
 
+const sandbox: SandboxObj = {
+    deleted: false,
+    region: '',
+    resources: [],
+    datasets: [],
+    studyId: '',
+    technicalContactEmail: '',
+    technicalContactName: '',
+    name: '',
+    template: '',
+    id: '',
+    currentPhase: undefined,
+    linkToCostAnalysis: '',
+    studyName: '',
+    restrictionDisplayText: '',
+    permissions: {
+        delete: false,
+        editInboundRules: false,
+        openInternet: false,
+        update: false,
+        increasePhase: false
+    }
+};
+
 const initialState: SandboxesState = {
-    callGetResources: false
+    callGetResources: false,
+    sandbox
 };
 
 export const sandboxesSlice = createSlice({
@@ -14,10 +41,13 @@ export const sandboxesSlice = createSlice({
     reducers: {
         setCallResources: (state: SandboxesState, action: PayloadAction<boolean>) => {
             return { ...state, callGetResources: action.payload };
+        },
+        setSandboxInStore: (state: SandboxesState, action: PayloadAction<any>) => {
+            return { ...state, sandbox: action.payload };
         }
     }
 });
 
-export const { setCallResources } = sandboxesSlice.actions;
+export const { setCallResources, setSandboxInStore } = sandboxesSlice.actions;
 
 export default sandboxesSlice.reducer;

--- a/src/tests/component_tests/sandbox/Stepbar.test.tsx
+++ b/src/tests/component_tests/sandbox/Stepbar.test.tsx
@@ -5,31 +5,35 @@ import { Router } from 'react-router-dom';
 import { sandboxWithAllPermissions, sandboxWithNoPermissions } from '../../mocks/sandbox/sandbox-mocks';
 import sandboxesReducer from '../../../store/sandboxes/sandboxesSlice';
 import resourcesReducer from '../../../store/resources/resourcesSlice';
-import { combineReducers, createStore } from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
 import { Provider } from 'react-redux';
 
 const mockFunc = (id: string) => {};
-const mockStore = createStore(
-    combineReducers({
-        sandboxes: sandboxesReducer,
-        resources: resourcesReducer
-    })
-);
+
+
+const initialStateWithPermissions = { sandboxes: { sandbox: sandboxWithAllPermissions, callGetResources: false }};
+const initialStateWithoutPermissions = { sandboxes: { sandbox: sandboxWithNoPermissions, callGetResources: false }};
+
+const mockStore = (state: any) => {
+    return configureStore({
+        reducer: {
+            sandboxes: sandboxesReducer,
+            resources: resourcesReducer
+        },    
+        preloadedState: state
+    });
+};
 
 test('renders stepbar component without permissions', async () => {
     const history = createMemoryHistory();
     const { getByText, getByTestId } = render(
-        <Provider store={mockStore}>
+        <Provider store={mockStore(initialStateWithoutPermissions)}>
             <Router history={history}>
                 <StepBar
-                    sandbox={sandboxWithNoPermissions}
                     sandboxId="1"
                     step={0}
                     studyId="1"
                     setStep={mockFunc}
-                    setSandbox={mockFunc}
-                    updateCache={mockFunc}
-                    setUpdateCache={mockFunc}
                     setLoading={mockFunc}
                     setNewPhase={mockFunc}
                     setDeleteSandboxInProgress={mockFunc}
@@ -39,6 +43,8 @@ test('renders stepbar component without permissions', async () => {
                     setMakeAvailableInProgress={mockFunc}
                     makeAvailableInProgress={false}
                     setHasChanged={mockFunc}
+                    updateCache={mockFunc}
+                    setUpdateCache={mockFunc}
                 />
             </Router>
         </Provider>
@@ -57,17 +63,13 @@ test('renders stepbar component without permissions', async () => {
 test('renders stepbar component with permissions', async () => {
     const history = createMemoryHistory();
     const { getByText, getByTestId } = render(
-        <Provider store={mockStore}>
+        <Provider store={mockStore(initialStateWithPermissions)}>
             <Router history={history}>
                 <StepBar
-                    sandbox={sandboxWithAllPermissions}
                     sandboxId="1"
                     step={0}
                     studyId="1"
                     setStep={mockFunc}
-                    setSandbox={mockFunc}
-                    updateCache={mockFunc}
-                    setUpdateCache={mockFunc}
                     setLoading={mockFunc}
                     setNewPhase={mockFunc}
                     setDeleteSandboxInProgress={mockFunc}
@@ -77,6 +79,8 @@ test('renders stepbar component with permissions', async () => {
                     setMakeAvailableInProgress={mockFunc}
                     makeAvailableInProgress={false}
                     setHasChanged={mockFunc}
+                    updateCache={mockFunc}
+                    setUpdateCache={mockFunc}
                 />
             </Router>
         </Provider>


### PR DESCRIPTION
Add sandbox to redux state management. The state is passed down to lot of child components.

closes #1506