### PR TITLE
fix(study): fix long loading screen

### DIFF
--- a/src/components/studyDetails/StudyFull.tsx
+++ b/src/components/studyDetails/StudyFull.tsx
@@ -260,7 +260,7 @@ const StudyComponentFull: React.FC<StudyComponentFullProps> = ({
         }
         setEditMode(false);
 
-        if (!wbsIsValid) {
+        if (!wbsOnChangeIsValid) {
             studyOnChange.wbsCode = '';
         }
 


### PR DESCRIPTION
Fix to long lasing screen when creating a study. Now the user has to wait until the WBS validated when creating a study.

Closes #1464